### PR TITLE
feat: add basic charts dashboard

### DIFF
--- a/client/src/components/ChartsDashboard.jsx
+++ b/client/src/components/ChartsDashboard.jsx
@@ -1,0 +1,156 @@
+import { useState, useMemo } from "react";
+import { MONTHS } from "./utils";
+import { filterByMonth } from "./utils/transactionsDerivers";
+
+// Simple SVG based charts to avoid extra dependencies
+const BarChart = ({ data, width = 300, height = 150 }) => {
+  const max = Math.max(...data.map((d) => d.value), 0);
+  const barWidth = width / data.length;
+  return (
+    <svg width={width} height={height}>
+      {data.map((d, i) => {
+        const barHeight = max ? (d.value / max) * (height - 20) : 0;
+        return (
+          <g key={d.label}>
+            <rect
+              x={i * barWidth + 5}
+              y={height - barHeight - 20}
+              width={barWidth - 10}
+              height={barHeight}
+              fill="#4e79a7"
+            />
+            <text
+              x={i * barWidth + barWidth / 2}
+              y={height - 5}
+              textAnchor="middle"
+              fontSize="10"
+            >
+              {d.label}
+            </text>
+          </g>
+        );
+      })}
+    </svg>
+  );
+};
+
+const PieChart = ({ data, size = 160 }) => {
+  const radius = size / 2;
+  const total = data.reduce((s, d) => s + d.value, 0);
+  let cumulative = 0;
+  const colors = ["#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f", "#edc949"];
+
+  return (
+    <svg width={size} height={size} viewBox={`0 0 ${size} ${size}`}>\n      {data.map((d, i) => {
+        const startAngle = (cumulative / total) * 2 * Math.PI;
+        cumulative += d.value;
+        const endAngle = (cumulative / total) * 2 * Math.PI;
+        const largeArc = endAngle - startAngle > Math.PI ? 1 : 0;
+        const x1 = radius + radius * Math.cos(startAngle);
+        const y1 = radius + radius * Math.sin(startAngle);
+        const x2 = radius + radius * Math.cos(endAngle);
+        const y2 = radius + radius * Math.sin(endAngle);
+        return (
+          <path
+            key={d.name}
+            d={`M${radius},${radius} L${x1},${y1} A${radius},${radius} 0 ${largeArc} 1 ${x2},${y2} z`}
+            fill={colors[i % colors.length]}
+          />
+        );
+      })}
+    </svg>
+  );
+};
+
+export default function ChartsDashboard({ transactions }) {
+  const [showBar, setShowBar] = useState(true);
+  const [showPie, setShowPie] = useState(true);
+  const [monthA, setMonthA] = useState(0);
+  const [monthB, setMonthB] = useState(1);
+  const [monthPie, setMonthPie] = useState(0);
+
+  const monthTotals = useMemo(() => (month) => {
+    const txs = filterByMonth(transactions, month);
+    return txs.reduce((s, t) => s + Number(t.depense || 0), 0);
+  }, [transactions]);
+
+  const barData = useMemo(
+    () => [
+      { label: MONTHS[monthA].slice(0, 3), value: monthTotals(monthA) },
+      { label: MONTHS[monthB].slice(0, 3), value: monthTotals(monthB) },
+    ],
+    [monthA, monthB, monthTotals]
+  );
+
+  const pieData = useMemo(() => {
+    const txs = filterByMonth(transactions, monthPie);
+    const totals = {};
+    txs.forEach((t) => {
+      const amount = Number(t.depense || 0);
+      if (!amount) return;
+      totals[t.theme] = (totals[t.theme] || 0) + amount;
+    });
+    return Object.entries(totals).map(([name, value]) => ({ name, value }));
+  }, [transactions, monthPie]);
+
+  return (
+    <div className="charts-dashboard">
+      <div className="charts-dashboard__controls">
+        <label>
+          <input
+            type="checkbox"
+            checked={showBar}
+            onChange={() => setShowBar((v) => !v)}
+          />
+          Comparaison
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPie}
+            onChange={() => setShowPie((v) => !v)}
+          />
+          Répartition
+        </label>
+      </div>
+
+      {showBar && (
+        <div className="charts-dashboard__chart">
+          <div className="charts-dashboard__filters">
+            <select value={monthA} onChange={(e) => setMonthA(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+            <select value={monthB} onChange={(e) => setMonthB(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+          <BarChart data={barData} />
+        </div>
+      )}
+
+      {showPie && (
+        <div className="charts-dashboard__chart">
+          <div className="charts-dashboard__filters">
+            <select value={monthPie} onChange={(e) => setMonthPie(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+          <PieChart data={pieData} />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/pages/App.jsx
+++ b/client/src/pages/App.jsx
@@ -13,6 +13,7 @@ import TransactionForm from "../components/TransactionForm";
 import TransactionsTable from "../components/TransactionsTable";
 import { useTransactionForm } from "../components/hooks/useTransactionForm";
 import { useTransactions } from "../components/hooks/useTransactions";
+import ChartsDashboard from "../components/ChartsDashboard";
 
 const App = () => {
   const { transactions, add, remove, update } = useTransactions();
@@ -20,6 +21,7 @@ const App = () => {
     useTransactionForm();
 
   const [selectedMonth, setSelectedMonth] = useState(null);
+  const [showCharts, setShowCharts] = useState(false);
 
   const onSubmit = useCallback(
     async (e) => {
@@ -60,7 +62,16 @@ const App = () => {
   );
 
   return (
-    <AppShell headerRight={<ThemeToggle />}>
+    <AppShell
+      headerRight={
+        <div style={{ display: "flex", gap: 8 }}>
+          <button onClick={() => setShowCharts((v) => !v)}>
+            {showCharts ? "Fermer les graphiques" : "Graphiques"}
+          </button>
+          <ThemeToggle />
+        </div>
+      }
+    >
       <div className="navBar">
         <MonthTabs
           months={MONTHS}
@@ -74,6 +85,9 @@ const App = () => {
           onSubmit={onSubmit}
         />
       </div>
+      {showCharts && (
+        <ChartsDashboard transactions={transactions} />
+      )}
       <TransactionsTable
         transactions={filteredTransactions}
         headers={TABLE_HEADERS}

--- a/client/src/sass/index.scss
+++ b/client/src/sass/index.scss
@@ -88,7 +88,7 @@ body {
   margin: 0 auto 1rem auto;
 }
 
-.month-tabs {
+  .month-tabs {
   // margin: 0 auto 1rem auto;
   width: 100%;
   max-width: 350px;
@@ -164,6 +164,26 @@ body {
       color: #fff;
       border-color: var(--color-accent);
     }
+  }
+}
+
+.charts-dashboard {
+  margin: 1rem 0;
+
+  &__controls {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  &__chart {
+    margin-bottom: 2rem;
+  }
+
+  &__filters {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- add ChartsDashboard component to compare months and view theme distribution
- allow toggling charts from main header
- style charts dashboard section

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e213052c8328b4c309bdc79a5fe1