### PR TITLE
feat: add chart.js-based charts dashboard

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -11,10 +11,12 @@
     "server": "json-server --watch db.json --port 3001"
   },
   "dependencies": {
+    "chart.js": "^4.5.0",
     "classnames": "^2.5.1",
     "framer-motion": "^12.23.12",
     "json-server": "^1.0.0-beta.3",
     "react": "^19.1.0",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.1.0",
     "sass": "^1.90.0"
   },

--- a/client/src/components/ChartsDashboard.jsx
+++ b/client/src/components/ChartsDashboard.jsx
@@ -1,0 +1,142 @@
+import { useState, useMemo } from "react";
+import { Bar, Pie } from "react-chartjs-2";
+import {
+  Chart as ChartJS,
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  ArcElement,
+} from "chart.js";
+import { MONTHS } from "./utils";
+import { filterByMonth } from "./utils/transactionsDerivers";
+
+ChartJS.register(
+  BarElement,
+  CategoryScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  ArcElement
+);
+
+export default function ChartsDashboard({ transactions }) {
+  const [showBar, setShowBar] = useState(true);
+  const [showPie, setShowPie] = useState(true);
+  const [monthA, setMonthA] = useState(0);
+  const [monthB, setMonthB] = useState(1);
+  const [monthPie, setMonthPie] = useState(0);
+
+  const monthTotals = useMemo(
+    () =>
+      (month) => {
+        const txs = filterByMonth(transactions, month);
+        return txs.reduce((s, t) => s + Number(t.depense || 0), 0);
+      },
+    [transactions]
+  );
+
+  const barData = useMemo(
+    () => ({
+      labels: [MONTHS[monthA].slice(0, 3), MONTHS[monthB].slice(0, 3)],
+      datasets: [
+        {
+          label: "Dépenses",
+          data: [monthTotals(monthA), monthTotals(monthB)],
+          backgroundColor: ["#4e79a7", "#f28e2b"],
+        },
+      ],
+    }),
+    [monthA, monthB, monthTotals]
+  );
+
+  const pieData = useMemo(() => {
+    const txs = filterByMonth(transactions, monthPie);
+    const totals = {};
+    txs.forEach((t) => {
+      const amount = Number(t.depense || 0);
+      if (!amount) return;
+      totals[t.theme] = (totals[t.theme] || 0) + amount;
+    });
+    const labels = Object.keys(totals);
+    const data = Object.values(totals);
+    const colors = ["#4e79a7", "#f28e2b", "#e15759", "#76b7b2", "#59a14f", "#edc949"];
+    return {
+      labels,
+      datasets: [
+        {
+          data,
+          backgroundColor: labels.map((_, i) => colors[i % colors.length]),
+        },
+      ],
+    };
+  }, [transactions, monthPie]);
+
+  return (
+    <div className="charts-dashboard">
+      <div className="charts-dashboard__controls">
+        <label>
+          <input
+            type="checkbox"
+            checked={showBar}
+            onChange={() => setShowBar((v) => !v)}
+          />
+          Comparaison
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            checked={showPie}
+            onChange={() => setShowPie((v) => !v)}
+          />
+          Répartition
+        </label>
+      </div>
+
+      {showBar && (
+        <div className="charts-dashboard__chart">
+          <div className="charts-dashboard__filters">
+            <select value={monthA} onChange={(e) => setMonthA(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+            <select value={monthB} onChange={(e) => setMonthB(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Bar
+            data={barData}
+            options={{
+              responsive: true,
+              plugins: { legend: { display: false } },
+            }}
+          />
+        </div>
+      )}
+
+      {showPie && (
+        <div className="charts-dashboard__chart">
+          <div className="charts-dashboard__filters">
+            <select value={monthPie} onChange={(e) => setMonthPie(Number(e.target.value))}>
+              {MONTHS.map((m, i) => (
+                <option key={m} value={i}>
+                  {m}
+                </option>
+              ))}
+            </select>
+          </div>
+          <Pie data={pieData} />
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/client/src/pages/App.jsx
+++ b/client/src/pages/App.jsx
@@ -13,6 +13,7 @@ import TransactionForm from "../components/TransactionForm";
 import TransactionsTable from "../components/TransactionsTable";
 import { useTransactionForm } from "../components/hooks/useTransactionForm";
 import { useTransactions } from "../components/hooks/useTransactions";
+import ChartsDashboard from "../components/ChartsDashboard";
 
 const App = () => {
   const { transactions, add, remove, update } = useTransactions();
@@ -20,6 +21,7 @@ const App = () => {
     useTransactionForm();
 
   const [selectedMonth, setSelectedMonth] = useState(null);
+  const [showCharts, setShowCharts] = useState(false);
 
   const onSubmit = useCallback(
     async (e) => {
@@ -60,7 +62,16 @@ const App = () => {
   );
 
   return (
-    <AppShell headerRight={<ThemeToggle />}>
+    <AppShell
+      headerRight={
+        <div style={{ display: "flex", gap: 8 }}>
+          <button onClick={() => setShowCharts((v) => !v)}>
+            {showCharts ? "Fermer les graphiques" : "Graphiques"}
+          </button>
+          <ThemeToggle />
+        </div>
+      }
+    >
       <div className="navBar">
         <MonthTabs
           months={MONTHS}
@@ -74,6 +85,9 @@ const App = () => {
           onSubmit={onSubmit}
         />
       </div>
+      {showCharts && (
+        <ChartsDashboard transactions={transactions} />
+      )}
       <TransactionsTable
         transactions={filteredTransactions}
         headers={TABLE_HEADERS}

--- a/client/src/sass/index.scss
+++ b/client/src/sass/index.scss
@@ -88,7 +88,7 @@ body {
   margin: 0 auto 1rem auto;
 }
 
-.month-tabs {
+  .month-tabs {
   // margin: 0 auto 1rem auto;
   width: 100%;
   max-width: 350px;
@@ -164,6 +164,26 @@ body {
       color: #fff;
       border-color: var(--color-accent);
     }
+  }
+}
+
+.charts-dashboard {
+  margin: 1rem 0;
+
+  &__controls {
+    display: flex;
+    gap: 1rem;
+    margin-bottom: 1rem;
+  }
+
+  &__chart {
+    margin-bottom: 2rem;
+  }
+
+  &__filters {
+    display: flex;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
   }
 }
 

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -423,6 +423,11 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
+"@kurkle/color@^0.3.0":
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
+  integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
+
 "@parcel/watcher-android-arm64@2.5.1":
   version "2.5.1"
   resolved "https://registry.yarnpkg.com/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz#507f836d7e2042f798c7d07ad19c3546f9848ac1"
@@ -915,6 +920,13 @@ chalk@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.5.0.tgz#67ada1df5ca809dc84c9b819d76418ddcf128428"
   integrity sha512-1tm8DTaJhPBG3bIkVeZt1iZM9GfSX2lzOeDVZH9R9ffRHpmHvxZ/QhgQH/aDTkswQVt+YHdXAdS/In/30OjCbg==
+
+chart.js@^4.5.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/chart.js/-/chart.js-4.5.0.tgz#11a1ef6c4befc514b1b0b613ebac226c4ad2740b"
+  integrity sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==
+  dependencies:
+    "@kurkle/color" "^0.3.0"
 
 chokidar@^4.0.0, chokidar@^4.0.1:
   version "4.0.3"
@@ -1568,6 +1580,11 @@ punycode@^2.1.0:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.3.1.tgz#027422e2faec0b25e1549c3e1bd8309b9133b6e5"
   integrity sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==
+
+react-chartjs-2@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz#2d3286339a742bc7f77b5829c33ebab215f714cc"
+  integrity sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==
 
 react-dom@^19.1.0:
   version "19.1.1"


### PR DESCRIPTION
## Summary
- integrate chart.js and react-chartjs-2 for bar and pie visualizations
- enable filterable charts with toggles to show or hide comparisons and distributions

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6899e213052c8328b4c309bdc79a5fe1